### PR TITLE
Improve lokalise api error handling

### DIFF
--- a/Api/Exceptions/LokaliseApiException.php
+++ b/Api/Exceptions/LokaliseApiException.php
@@ -2,7 +2,32 @@
 
 namespace Lokalise\Exceptions;
 
-class LokaliseApiException extends \Exception
-{
+use Exception;
+use Psr\Http\Message\ResponseInterface;
+use Throwable;
 
+class LokaliseApiException extends Exception
+{
+    protected ?ResponseInterface $response = null;
+
+    public function __construct(
+        string $message = '',
+        int $code = 0,
+        ?Throwable $previous = null,
+        ?ResponseInterface $response = null
+    ) {
+        $this->response = $response;
+
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function hasResponse(): bool
+    {
+        return $this->response !== null;
+    }
+
+    public function getResponse(): ?ResponseInterface
+    {
+        return $this->response;
+    }
 }


### PR DESCRIPTION
- Chain exceptions so debugging is easier and we know exactly what went wrong.
- Attach the response object whenever available when throwing an api exception. Clients may be interested in further processing the response object. Currently the `LokaliseApiException` swallows the original exception and response.