### PR TITLE
Fixed merging of empty results in requestAllUsingCursor()

### DIFF
--- a/Api/Endpoints/Endpoint.php
+++ b/Api/Endpoints/Endpoint.php
@@ -188,24 +188,22 @@ class Endpoint implements EndpointInterface
     ): LokaliseApiResponse
     {
         $bodyData = [];
-        $cursor = '';
         $queryParams['limit'] = static::FETCH_ALL_LIMIT;
         $queryParams['pagination'] = 'cursor';
-        while (true) {
+        $result = $this->request($requestType, $uri, $queryParams, $body);
+        $cursor = $result->getNextCursor();
+
+        while (!empty($cursor)) {
             $queryParams['cursor'] = $cursor;
 
-            $result = $this->request($requestType, $uri, $queryParams, $body);
+            $nextResult = $this->request($requestType, $uri, $queryParams, $body);
 
-            if (is_array($result->body[$bodyResponseKey]) && !empty($result->body[$bodyResponseKey])) {
-                $bodyData = array_merge($bodyData, $result->body[$bodyResponseKey]);
+            if (is_array($nextResult->body[$bodyResponseKey]) && !empty($nextResult->body[$bodyResponseKey])) {
+                $bodyData = array_merge($bodyData, $nextResult->body[$bodyResponseKey]);
                 $result->body[$bodyResponseKey] = $bodyData;
             }
 
-            if (!$result->hasNextCursor()) {
-                break;
-            }
-
-            $cursor = $result->getNextCursor();
+            $cursor = $nextResult->getNextCursor();
         }
 
         return $result;


### PR DESCRIPTION
This PR fixes https://github.com/lokalise/php-lokalise-api/issues/33.

`\Lokalise\Endpoints\Endpoint::requestAllUsingCursor()` was overwriting previous results if the Lokalise API returned a cursor but the next result page didn't include any results.

